### PR TITLE
fix: update make targets to use trivy

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -69,5 +69,5 @@ rule "terraform_workspace_remote" {
 }
 
 rule "terraform_unused_required_provider" {
-  enabled = false
+  enabled = true
 }

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -67,7 +67,3 @@ rule "terraform_standard_module_structure" {
 rule "terraform_workspace_remote" {
   enabled = true
 }
-
-rule "terraform_unused_required_provider" {
-  enabled = true
-}

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ init:
 
 security: 
 	@echo "--> Running Security checks"
-	@tfsec .
+	@trivy config .
 	$(MAKE) security-modules
 	$(MAKE) security-examples
 
@@ -65,7 +65,7 @@ security-modules:
 	@if [ -d modules ]; then \
 		find modules -type d -mindepth 1 -maxdepth 1 | while read -r dir; do \
 			echo "--> Validating $$dir"; \
-			tfsec $$dir; \
+			trivy config $$dir; \
 		done; \
 	fi
 
@@ -74,7 +74,7 @@ security-examples:
 	@if [ -d examples ]; then \
 		find examples -type d -mindepth 1 -maxdepth 1 | while read -r dir; do \
 			echo "--> Validating $$dir"; \
-			tfsec $$dir; \
+			trivy config $$dir; \
 		done; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.24.0 |
 
 ## Providers
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -5,7 +5,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.11.0 |
 
 ## Providers
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,6 +3,7 @@ terraform {
   required_version = ">= 1.0.7"
 
   required_providers {
+    # tflint-ignore: terraform_unused_required_providers
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0.0"


### PR DESCRIPTION
## what
This change ensures that `trivy` is used as the IaC security scanner instead of `tfsec`. It uses the [Aqua Security Vulnerability Database](https://avd.aquasec.com/misconfig/aws/) to identify terraform misconfigurations that may lead to potential security threats.

## why
Aqua Security is moving towards consolidating all their scanning-related efforts into Trivy, and therefore have encouraged all users to migrate from `tfsec` to `trivy`.

## references
- https://github.com/aquasecurity/tfsec/tree/master?tab=readme-ov-file#-tfsec-to-trivy-migration